### PR TITLE
Add missing var name in compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -34,6 +34,6 @@ EOF
 chmod +x $BUILD_DIR/bin/run_cloud_sql_proxy
 
 echo "-----> Adding ENV guard for running cloud_sql_proxy into slug"
-cp "$BUILD_DIR/bin/start-cloudsql-proxy" $BUILD_DIR/bin/
+cp "$BUILDPACK_DIR/bin/start-cloudsql-proxy" $BUILD_DIR/bin/
 chmod +x $BUILD_DIR/bin/start-cloudsql-proxy
 exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -5,6 +5,7 @@ set -e
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
+BUILDPACK_DIR="$(dirname $(dirname $0))"
 
 if [ ! -f $CACHE_DIR/cloud_sql_proxy ]; then
 	echo "-----> Downloading cloud_sql_proxy"
@@ -33,6 +34,6 @@ EOF
 chmod +x $BUILD_DIR/bin/run_cloud_sql_proxy
 
 echo "-----> Adding ENV guard for running cloud_sql_proxy into slug"
-cp "$BUILDPACK_DIR/bin/start-cloudsql-proxy" $BUILD_DIR/bin/
+cp "$BUILD_DIR/bin/start-cloudsql-proxy" $BUILD_DIR/bin/
 chmod +x $BUILD_DIR/bin/start-cloudsql-proxy
 exit 0


### PR DESCRIPTION
Forgot to specify the BUILDPACK_DIR to copy from.